### PR TITLE
exporting package json to support svelte framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     },
     "./lite/*": "./lite/*",
     "./ultra_lite/*": "./ultra_lite/*",
-    "./dist/*": "./dist/*"
+    "./dist/*": "./dist/*",
+    "./package.json": "./package.json"
   },
   "files": [
     "fuzzball.js",


### PR DESCRIPTION
I'm trying to use fuzzball in my svelte project and getting following error.
After exporting `./package.json` building my source started working.
<img width="1111" alt="Screenshot 2021-11-19 at 20 07 58" src="https://user-images.githubusercontent.com/10027416/142685413-02462283-0a08-4dee-83ec-737ca7affc6d.png">
